### PR TITLE
Add option --skip-write-hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
   --cwd [cwd]                 Current working directory.
   --hash-filename [filename]  Filename where hash of dependencies will be written to
   --lockfile                  Include package-lock.json content in hash
+  --skip-write-hash           Skip writing new hash to .packagehash file
   -h, --help                  display help for command
 
 Commands:
@@ -127,6 +128,7 @@ isPackageChanged(
 | cwd           | string  | Current working directory                               | false    | `process.cwd()`  |
 | hashFilename  | string  | Filename where hash of dependencies will be written to. | false    | `'.packagehash'` |
 | lockfile      | boolean | Include package-lock.json content in hash.              | false    | `false`          |
+| skipWriteHash | boolean | Skip writing new hash to .packagehash file.              | false    | `false`          |
 
 
 **PackageChangedCallbackResult**

--- a/bin/package-changed.js
+++ b/bin/package-changed.js
@@ -8,7 +8,8 @@ const { isPackageChanged } = require('../lib/index');
 program
     .option('--cwd [cwd]', 'Current working directory.')
     .option('--hash-filename [filename]', 'Filename where hash of dependencies will be written to')
-    .option('--lockfile', 'Include package-lock.json content in hash');
+    .option('--lockfile', 'Include package-lock.json content in hash')
+    .option('--skip-write-hash', 'Skip writing new hash to .packagehash file');
 
 program.command('run [command]', { isDefault: false }).action(async (command) => {
     const cwd = program.cwd || process.cwd();
@@ -17,6 +18,7 @@ program.command('run [command]', { isDefault: false }).action(async (command) =>
             cwd,
             hashFilename: program.hashFilename,
             lockfile: program.lockfile,
+            skipWriteHash: program.skipWriteHash,
         },
         ({ isChanged }) => {
             if (isChanged && command) {
@@ -44,6 +46,7 @@ program
                 cwd,
                 hashFilename: program.hashFilename,
                 lockfile: program.lockfile,
+                skipWriteHash: program.skipWriteHash,
             },
             ({ isChanged }) => {
                 if (isChanged) {

--- a/src/is-package-changed.ts
+++ b/src/is-package-changed.ts
@@ -16,6 +16,7 @@ interface PackageChangedOptions {
     hashFilename?: string;
     cwd?: string;
     lockfile?: boolean;
+    skipWriteHash?: boolean;
 }
 
 interface PackageChangedCallback {
@@ -33,7 +34,7 @@ async function isPackageChanged(
     options: PackageChangedOptions = {},
     callback?: PackageChangedCallback,
 ): Promise<PackageChangedResult | Omit<PackageChangedResult, 'writeHash'>> {
-    const { hashFilename = '.packagehash', cwd = process.cwd(), lockfile } = options;
+    const { hashFilename = '.packagehash', cwd = process.cwd(), lockfile, skipWriteHash } = options;
     const packagePath = findPackage({ cwd });
     if (!packagePath) {
         throw new Error('Cannot find package.json. Travelling up from current working directory.');
@@ -74,7 +75,7 @@ async function isPackageChanged(
         if (canWriteHash === undefined) {
             canWriteHash = process.env.CI !== 'true';
         }
-        if (canWriteHash) {
+        if (canWriteHash && !skipWriteHash) {
             writeHash(result.hash);
         }
     }


### PR DESCRIPTION
As discussed in pr #4, separated --skip-write-hash. Will also add an additional pr for an alternative name for same feautre so you can chose.