### PR TITLE
bugfix/no-hash-file

### DIFF
--- a/bin/package-changed.js
+++ b/bin/package-changed.js
@@ -18,7 +18,7 @@ program.command('run [command]', { isDefault: false }).action(async (command) =>
             cwd,
             hashFilename: program.hashFilename,
             lockfile: program.lockfile,
-            noHashFile: program.noHashFile,
+            noHashFile: !program.hashFile,
         },
         ({ isChanged }) => {
             if (isChanged && command) {
@@ -46,7 +46,7 @@ program
                 cwd,
                 hashFilename: program.hashFilename,
                 lockfile: program.lockfile,
-                noHashFile: program.noHashFile,
+                noHashFile: !program.hashFile,
             },
             ({ isChanged }) => {
                 if (isChanged) {


### PR DESCRIPTION
Please release this bugfix I noted today. 
We really use this plugin and its helping us a lot to skip communicating dependency updates.
Hope you have the time for it.

Thanks in advance!
@thdk 