### PR TITLE
version bump or name change should not update hash

### DIFF
--- a/src/get-packagelock-hash.ts
+++ b/src/get-packagelock-hash.ts
@@ -5,6 +5,13 @@ export const getPackagelockHash = (packagelockPath?: string): string | undefined
     if (!packagelockPath) return;
     const hashSum = crypto.createHash('md5');
     const contents = fs.readFileSync(packagelockPath, 'utf-8');
-    hashSum.update(Buffer.from(contents));
+    const packageBlob = JSON.parse(contents);
+
+    delete packageBlob.name;
+    delete packageBlob['packages']?.['']?.name;
+    delete packageBlob.version;
+    delete packageBlob['packages']?.['']?.version;
+    const fileJson = JSON.stringify(packageBlob);
+    hashSum.update(Buffer.from(fileJson));
     return hashSum.digest('hex');
 };


### PR DESCRIPTION
Deleting name and version from packagelock content before creating hash so that a version bump or name change dont make hash update.
This since no dependencies has not been changed then.