### PR TITLE
change writeHash to use a default parameter instead of bind (#17)

### DIFF
--- a/src/is-package-changed.ts
+++ b/src/is-package-changed.ts
@@ -8,7 +8,7 @@ import { getPackagelock } from './get-packagelock';
 interface PackageChangedResult {
     hash: string;
     oldHash: string | undefined;
-    writeHash(): void;
+    writeHash(hash?: string): void;
     isChanged: boolean;
 }
 
@@ -45,8 +45,6 @@ async function isPackageChanged(
     }
 
     const packageHashPath = path.join(cwd, hashFilename);
-    const writeHash = (hash: string | undefined) =>
-        hash && fs.writeFileSync(packageHashPath, hash, {});
 
     const packageHashPathExists = fs.existsSync(packageHashPath);
     const recentDigest = lockfile
@@ -63,6 +61,9 @@ async function isPackageChanged(
         isChanged,
         oldHash: previousDigest || undefined,
     };
+
+    const writeHash = (hash: string | undefined = result.hash) =>
+        hash && fs.writeFileSync(packageHashPath, hash, {});
 
     if (callback) {
         let canWriteHash = await callback(result);
@@ -82,7 +83,7 @@ async function isPackageChanged(
 
     return {
         ...result,
-        writeHash: writeHash.bind(null, result.hash),
+        writeHash,
     };
 }
 


### PR DESCRIPTION
This PR allows you to write a custom hash. This is primarily a workaround for #16

With these changes, I can now do something like

```js
/** @type {import('package-changed/types')} */
const { isPackageChanged } = require('package-changed');

/** @type {import('child_process')} */
const { execSync } = require('node:child_process');

(async () => {
    const { oldHash, hash: rootHash, writeHash } = await isPackageChanged({ noHashFile: true });
    const { hash: nextjsHash } = await isPackageChanged({ noHashFile: true, cwd: './nextjs' });

    const newHash = `${rootHash}${nextjsHash}`;

    if (newHash !== oldHash) {
        console.log("Package changed. Running 'rm -f .eslintcache && pnpm install'.");
        // dependencies in a package.json have changed since last run
        execSync('rm -f .eslintcache');
        execSync('pnpm install');

        writeHash(newHash);
    }
})();
```