### PR TITLE
replace husky add in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Options:
 With Husky installed:
 
 ```shell
-npx husky add .husky/post-checkout "npx --no package-changed"
-npx husky add .husky/post-merge "npx --no package-changed"
-npx husky add .husky/post-rebase "npx --no package-changed"
+echo "npx --no -- package-changed --lockfile" >.husky/post-checkout
+echo "npx --no -- package-changed --lockfile" >.husky/post-merge
+echo "npx --no -- package-changed --lockfile" >.husky/post-rebase
 ```
 
 


### PR DESCRIPTION
husky add is deprecated, use echo instead

I also included passing the `--lockfile` argument in the example as I believe it's the most desirable default behavior. The important thing to do there is adding the `--` right before `package-changed` so that the `--lockfile` argument is passed to `package-changed` and not read by `npx` itself.

p.s. I accidentally created https://github.com/nemchik/package-changed/pull/5 months ago instead of creating it correctly here 😆 